### PR TITLE
Added zrevrangebyscore commands (with update to Jedis 2.0.0)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject clj-redis "0.0.13-SNAPSHOT"
+(defproject clj-redis "0.0.14-SNAPSHOT"
   :description "Clojure Redis client library"
   :url "https://github.com/mmcgrana/clj-redis"
   :dependencies [[org.clojure/clojure "[1.2.0,1.3.0]"]
-                 [redis.clients/jedis "1.5.2"]]
+                 [redis.clients/jedis "2.0.0"]]
   :multi-deps {"1.3" [[org.clojure/clojure "1.3.0"]
                       [redis.clients/jedis "1.5.2"]]
                "1.2" [[org.clojure/clojure "1.2.1"]
-                      [redis.clients/jedis "1.5.2"]]}
+                      [redis.clients/jedis "2.0.0"]]}
   :dev-deps [[lein-multi "1.0.0"]])

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ The connections represented by the return value of `clj-redis.client/init` are t
 
 ## Installation
 
-Depend on `[clj-redis "0.0.14"]` in your `project.clj`.
+Depend on `[clj-redis "0.0.13"]` in your `project.clj`.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ The connections represented by the return value of `clj-redis.client/init` are t
 
 ## Installation
 
-Depend on `[clj-redis "0.0.13"]` in your `project.clj`.
+Depend on `[clj-redis "0.0.12"]` in your `project.clj`.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,9 @@ Clojure [Redis](http://redis.io) client library.
 ## Usage
 
     (require '[clj-redis.client :as redis])
-    
+
     (def db (redis/init))
-    
+
     (redis/ping db)
     => "PONG"
 
@@ -24,7 +24,7 @@ The connections represented by the return value of `clj-redis.client/init` are t
 
 ## Installation
 
-Depend on `[clj-redis "0.0.12"]` in your `project.clj`.
+Depend on `[clj-redis "0.0.14"]` in your `project.clj`.
 
 ## License
 

--- a/src/clj_redis/client.clj
+++ b/src/clj_redis/client.clj
@@ -216,9 +216,9 @@
 
 (defn zrangebyscore-withscore
   ([p ^String k ^Double min ^Double max]
-    (lease p (fn [^Jedis j] (seq (.zrangeByScoreWithScore j k min max)))))
+    (lease p (fn [^Jedis j] (seq (.zrangeByScoreWithScores j k min max)))))
   ([p ^String k ^Double min ^Double max ^Integer offset ^Integer count]
-    (lease p (fn [^Jedis j] (seq (.zrangeByScoreWithScore j k min max offset count))))))
+    (lease p (fn [^Jedis j] (seq (.zrangeByScoreWithScores j k min max offset count))))))
 
 (defn zrevrangebyscore
   ([p ^String k ^Double min ^Double max]
@@ -228,9 +228,9 @@
 
 (defn zrevrangebyscore-withscore
   ([p ^String k ^Double min ^Double max]
-    (lease p (fn [^Jedis j] (seq (.zrevrangeByScoreWithScore j k min max)))))
+    (lease p (fn [^Jedis j] (seq (.zrevrangeByScoreWithScores j k min max)))))
   ([p ^String k ^Double min ^Double max ^Integer offset ^Integer count]
-    (lease p (fn [^Jedis j] (seq (.zrevrangeByScoreWithScore j k min max offset count))))))
+    (lease p (fn [^Jedis j] (seq (.zrevrangeByScoreWithScores j k min max offset count))))))
 
 (defn zrange [p ^String k ^Integer start ^Integer end]
   (lease p (fn [^Jedis j] (seq (.zrange j k start end)))))

--- a/src/clj_redis/client.clj
+++ b/src/clj_redis/client.clj
@@ -220,6 +220,18 @@
   ([p ^String k ^Double min ^Double max ^Integer offset ^Integer count]
     (lease p (fn [^Jedis j] (seq (.zrangeByScoreWithScore j k min max offset count))))))
 
+(defn zrevrangebyscore
+  ([p ^String k ^Double min ^Double max]
+    (lease p (fn [^Jedis j] (seq (.zrevrangeByScore j k min max)))))
+  ([p ^String k ^Double min ^Double max ^Integer offset ^Integer count]
+    (lease p (fn [^Jedis j] (seq (.zrevrangeByScore j k min max offset count))))))
+
+(defn zrevrangebyscore-withscore
+  ([p ^String k ^Double min ^Double max]
+    (lease p (fn [^Jedis j] (seq (.zrevrangeByScoreWithScore j k min max)))))
+  ([p ^String k ^Double min ^Double max ^Integer offset ^Integer count]
+    (lease p (fn [^Jedis j] (seq (.zrevrangeByScoreWithScore j k min max offset count))))))
+
 (defn zrange [p ^String k ^Integer start ^Integer end]
   (lease p (fn [^Jedis j] (seq (.zrange j k start end)))))
 


### PR DESCRIPTION
Redis introduced the following command in version 2.1.6: -
- ZREVRANGEBYSCORE

Jedis added these in Jedis-2.0.0.

I've added them to the project accordingly. 

Also the `zrangewithscore` functions have been updated to reference the Jedis counterpart which are pluralised in 2.0.0 e.g. `zRangeWithScores` 
