### PR TITLE
Missing {} around arguments to init in test/client.clj

### DIFF
--- a/test/clj_redis/test/client.clj
+++ b/test/clj_redis/test/client.clj
@@ -4,7 +4,7 @@
         [clj-redis.client]))
 
 (deftest test-client
-  (let [db (init :url "redis://localhost")
+  (let [db (init {:url "redis://localhost"})
         [k v] ["foo" "bar"]]
     (is (= "PONG" (ping db)))
     (set db k v)


### PR DESCRIPTION
As there are no docs I was using the test/client.clj to understand how use this library and found that the test was missing some syntax that is critical to actually let it accept the argument passed to it.
